### PR TITLE
Add Carthage/Build into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ DerivedData
 *.ipa
 *.xcuserstate
 *.xcscmblueprint
+
+Carthage/Build


### PR DESCRIPTION
This is so that things work smoothly with carthage with its `--use-submodules` flag